### PR TITLE
(RN0.40.0) Fixed ios native headers

### DIFF
--- a/RCTPrivacySnapshot/RCTPrivacySnapshot.h
+++ b/RCTPrivacySnapshot/RCTPrivacySnapshot.h
@@ -6,7 +6,7 @@
 //  Copyright © 2015 Kayla Technologies. All rights reserved.
 //
 
-#import <RCTBridge.h>
+#import <React/RCTBridge.h>
 
 @interface RCTPrivacySnapshot : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
The import syntax has changed in react-native v0.40.0.
ref. https://github.com/facebook/react-native/releases/tag/v0.40.0

This PR follows new import syntax,
and need a major version bump for react-native 0.40.

Thanks!